### PR TITLE
Rename podcast.haiji.co to export.fm

### DIFF
--- a/data/rss.json
+++ b/data/rss.json
@@ -270,9 +270,9 @@
     "hashtag": "#gunosyfm"
   },
   "haijico": {
-    "feed": "https://podcast.haiji.co/feed",
-    "twitter": null,
-    "hashtag": "#haijico"
+    "feed": "https://export.fm/feed",
+    "twitter": "@exportfm",
+    "hashtag": "#exportfm"
   },
   "hbSAKABA": {
     "feed": "https://heartbeats.jp/hbsakaba/rss",


### PR DESCRIPTION
Thank you for running this website, we know some visitors are actually coming from here and appreciate for that.
Recently, [we renamed the podcast's title](https://export.fm/007), that makes the changes for Twitter account, hashtag and URL. So this PR brings the latest metadata.

Confirmed the data appears correctly in my local. Hope you deliver this to the production.
![image](https://user-images.githubusercontent.com/85887/64136550-2675d600-cda7-11e9-8362-46bd612a127e.png)

Cheers ✨ 